### PR TITLE
evaluate 'Description above field' setting of webform component

### DIFF
--- a/src/webform.forms.js
+++ b/src/webform.forms.js
@@ -54,10 +54,13 @@ function webform_form(form, form_state, entity, entity_type, bundle) {
         form.elements[component.form_key] = {
           component: component,
           type: component.type,
-          title: title,
+          title: (component.extra.description_above) ? '' : title,
           required: required,
           value: webform_tokens_replace(component.value),
-          description: webform_tokens_replace(component.extra.description),
+          description: (component.extra.description_above) ? '' : webform_tokens_replace(component.extra.description),
+          prefix: (component.extra.description_above) ?
+            theme('form_element_label', {'element': {'title': title}}) +
+            '<div class="description">' + webform_tokens_replace(component.extra.description) + '</div>' : '',
           disabled: component.extra.disabled,
           access: access,
           options: {


### PR DESCRIPTION
There is a webform component setting called 'Description above field'. 
If it is set the description is placed above — rather than below — the field. 
#16
